### PR TITLE
VP-3575: Fix wrong counter in preview blade of product association

### DIFF
--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
@@ -7,6 +7,8 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                 $scope.items = [];
                 $scope.blade.headIcon = 'fa-upload';
 
+                const maxPreviewItemCount = 10000;
+
                 var blade = $scope.blade;
                 var bladeNavigationService = bladeUtils.bladeNavigationService;
                 blade.isLoading = true;
@@ -36,7 +38,7 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                 function maxAssociationsCount(){
                     let countDataRequest = buildDataQuery();
                     countDataRequest.skip = 0;
-                    countDataRequest.take = 10000;
+                    countDataRequest.take = maxPreviewItemCount;
                     associations.preview(countDataRequest, (data) => {
                         $scope.pageSettings.totalItems = data.length;
                     })

--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
@@ -28,9 +28,19 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                         $scope.pageSettings.currentPage = 1;
                     }
 
+                    calculateTotals();
                     loadData();
                     resetStateGrid();
                 };
+
+                function calculateTotals(){
+                    let countDataRequest = buildDataQuery();
+                    countDataRequest.skip = 0;
+                    countDataRequest.take = 1000;
+                    associations.preview(countDataRequest, (data) => {
+                        $scope.pageSettings.totalItems = data.length;
+                    })
+                } 
 
                 function loadData(callback) {
                     blade.isLoading = true;
@@ -40,10 +50,7 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                     associations.preview(dataRequest, (data) => {
                         let productIds = data;
                         blade.isLoading = false;
-                        $scope.pageSettings.totalItems = data.length;
-                            //$scope.items = $scope.items.concat(data);
                         $scope.hasMore = data.length === $scope.pageSettings.itemsPerPageCount;
-
 
                         items.getByIds({ ids: productIds},
                             response => {

--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
@@ -30,12 +30,12 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                         $scope.pageSettings.currentPage = 1;
                     }
 
-                    maxAssociationsCount();
+                    calculateTotals();
                     loadData();
                     resetStateGrid();
                 };
 
-                function maxAssociationsCount(){
+                function calculateTotals(){
                     let countDataRequest = buildDataQuery();
                     countDataRequest.skip = 0;
                     countDataRequest.take = maxPreviewItemCount;

--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociation-viewer.js
@@ -28,15 +28,15 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                         $scope.pageSettings.currentPage = 1;
                     }
 
-                    calculateTotals();
+                    maxAssociationsCount();
                     loadData();
                     resetStateGrid();
                 };
 
-                function calculateTotals(){
+                function maxAssociationsCount(){
                     let countDataRequest = buildDataQuery();
                     countDataRequest.skip = 0;
-                    countDataRequest.take = 1000;
+                    countDataRequest.take = 10000;
                     associations.preview(countDataRequest, (data) => {
                         $scope.pageSettings.totalItems = data.length;
                     })

--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociations-detail.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociations-detail.js
@@ -2,6 +2,9 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
     .controller('virtoCommerce.dynamicAssociationsModule.dynamicAssociationDetailController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.dynamicAssociationsModule.dynamicAssociations', 'virtoCommerce.storeModule.stores', function ($scope, bladeNavigationService, associations, stores) {
         var blade = $scope.blade;
         var formScope;
+
+        const maxPreviewItemCount = 10000;
+        
         $scope.setForm = (form) => { formScope = form; };
 
         $scope.BlockMatchingRules = 'BlockMatchingRules';
@@ -287,7 +290,7 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                 categoryIds: categoryIds,
                 propertyValues: propertyValues,
                 skip: 0,
-                take: 10000
+                take: maxPreviewItemCount
             };
             return dataQuery;
 

--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociations-detail.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/dynamicAssociations-detail.js
@@ -287,7 +287,7 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                 categoryIds: categoryIds,
                 propertyValues: propertyValues,
                 skip: 0,
-                take: 1000
+                take: 10000
             };
             return dataQuery;
 


### PR DESCRIPTION
### Problem
Wrong counter in preview blade of product association

### Solution
Add additional query to receive total count.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
