### PR TITLE
Add handler for logging dynamic association changes

### DIFF
--- a/src/VirtoCommerce.DynamicAssociationsModule.Data/Handlers/LogChangesChangedEventHandler.cs
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Data/Handlers/LogChangesChangedEventHandler.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Hangfire;
+using VirtoCommerce.DynamicAssociationsModule.Core.Events;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+
+namespace VirtoCommerce.DynamicAssociationsModule.Data.Handlers
+{
+    public class LogChangesChangedEventHandler : IEventHandler<AssociationChangedEvent>
+    {
+        private readonly IChangeLogService _changeLogService;
+
+        public LogChangesChangedEventHandler(IChangeLogService changeLogService)
+        {
+            _changeLogService = changeLogService;
+        }
+
+        public Task Handle(AssociationChangedEvent message)
+        {
+            var logOperations = message
+                .ChangedEntries
+                .Select(x => AbstractTypeFactory<OperationLog>.TryCreateInstance().FromChangedEntry(x))
+                .ToArray();
+
+            BackgroundJob.Enqueue(() => LogEntityChangesInBackground(logOperations));
+
+            return Task.CompletedTask;
+        }
+
+        [DisableConcurrentExecution(10)]
+        public virtual void LogEntityChangesInBackground(OperationLog[] operationLogs)
+        {
+            _changeLogService.SaveChangesAsync(operationLogs).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/VirtoCommerce.DynamicAssociationsModule.Data/VirtoCommerce.DynamicAssociationsModule.Data.csproj
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Data/VirtoCommerce.DynamicAssociationsModule.Data.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hangfire" Version="1.7.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
It is done to update lastmodifieddate for storefront cache invalidation purposes.

### Problem
So dynamic association module don't handle association changed event, lastmodifieddate that required by storefront to invalidate cache is not changed,

### Solution
Need to use change log service, to update lastmodifieddate

### Proposed of changes
Add association event handler to update lastmodifieddate

### Additional context (optional)
![lastmodifieddate](https://user-images.githubusercontent.com/15198683/96711174-6fb72980-139d-11eb-96f0-de23d9322a9f.gif)

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
