### PR TITLE
VCST-4359: Use search store instead of query

### DIFF
--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/mainParameters.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/mainParameters.js
@@ -5,6 +5,7 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
         blade.headIcon = 'fa fa-area-chart';
         var formScope;
         $scope.setForm = (form) => { formScope = form; };
+        $scope.storeDataSource = (criteria) => stores.search(criteria);
 
         $scope.isValid = function() {
             return formScope && formScope.$valid;
@@ -19,18 +20,17 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                 }
             });
 
-            stores.query({}, response => {
-                $scope.stores = response;
-                if (parentRefresh) {
-                    blade.parentBlade.refresh();
-                }
-                blade.isLoading = false;
-            });
+            if (parentRefresh) {
+                blade.parentBlade.refresh();
+            }
+            blade.isLoading = false;
 
             blade.currentEntity = angular.copy(blade.originalEntity);
         };
 
-        $scope.onStoreSelected = ($item) => blade.currentEntity.catalogId = $item.catalog;
+        $scope.onStoreSelected = (item) => {
+            blade.currentEntity.catalogId = item.catalog;
+        };
         
         // datepicker 
         $scope.datepickers = {

--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/mainParameters.js
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/mainParameters.js
@@ -18,12 +18,12 @@ angular.module('virtoCommerce.dynamicAssociationsModule')
                 if (data && data.length > 0) {
                     blade.associationType = data[0];
                 }
+                blade.isLoading = false;
             });
 
             if (parentRefresh) {
                 blade.parentBlade.refresh();
             }
-            blade.isLoading = false;
 
             blade.currentEntity = angular.copy(blade.originalEntity);
         };

--- a/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/mainParameters.tpl.html
+++ b/src/VirtoCommerce.DynamicAssociationsModule.Web/Scripts/blades/mainParameters.tpl.html
@@ -49,12 +49,12 @@
                             <div class="form-group __info list">
                                 <label class="form-label">{{ 'dynamicAssociations.blades.dynamicAssociation-parameters.labels.store' | translate }}</label>
                                 <div class="form-input">
-                                    <ui-select ng-model="blade.currentEntity.storeId" required on-select="onStoreSelected($item)">
-                                        <ui-select-match placeholder="{{'dynamicAssociations.blades.dynamicAssociation-parameters.placeholders.store' | translate}}">{{$select.selected.name}}</ui-select-match>
-                                        <ui-select-choices repeat="x.id as x in stores">
-                                            <span ng-bind-html="x.name | highlight: $select.search"></span>
-                                        </ui-select-choices>
-                                    </ui-select>
+                                    <ui-scroll-drop-down data="storeDataSource(criteria)"
+                                                         required
+                                                         on-select="onStoreSelected(item)"
+                                                         placeholder="'dynamicAssociations.blades.dynamicAssociation-parameters.placeholders.store'"
+                                                         ng-model="blade.currentEntity.storeId">
+                                    </ui-scroll-drop-down>
                                 </div>
                                 <div class="list-descr">{{ 'dynamicAssociations.blades.dynamicAssociation-parameters.descriptions.store' | translate }}</div>
                             </div>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4359
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.DynamicAssociationsModule_3.812.0-pr-54-ef16.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the store selector to an async, search-backed dropdown in the dynamic association parameters blade.
> 
> - Replaces `ui-select` + preloaded `stores.query` with `ui-scroll-drop-down` using `stores.search` via new `storeDataSource(criteria)`
> - Removes synchronous stores loading; updates `onStoreSelected(item)` and maintains `catalogId` assignment
> - Minor refresh flow tweak: parent blade refresh invoked after settings load; preserves `isLoading` handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef16322b82f6adc44fd8ad915c1989dd3d4416bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->